### PR TITLE
fix(knex): remove useNullAsDefault warning

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -7,6 +7,7 @@ module.exports = {
     connection: {
       filename: './mydb.sqlite',
     },
+    useNullAsDefault: true,
   },
 
   production: {


### PR DESCRIPTION
## Issue

```
Knex:warning - sqlite does not support inserting default values. Set the `useNullAsDefault` flag to hide this warning. (see docs http://knexjs.org/#Builder-insert).
```

## Reference

https://github.com/apollographql/GitHunt-API/blob/master/knexfile.js#L14